### PR TITLE
Fix for previous version of elfinder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "robloach/component-installer": "*",
-        "components/jquery": ">=1.12.4 <4.0",
+        "components/jquery": ">=1.12.4 <3.5",
         "components/jqueryui": ">=1.12.0"
     },
     "extra": {


### PR DESCRIPTION
Hi,

For users requiring FMElfinderBundle 9 and  to recent issue https://github.com/Studio-42/elFinder/issues/3148 we are facing a bug with jQuery > 3.4. I know this repo is deprecated in favor of version 10 of FMElfinderBundle but it's difficult to me to upgrade.